### PR TITLE
ページネーションの追加

### DIFF
--- a/app/Http/Controllers/LikeController.php
+++ b/app/Http/Controllers/LikeController.php
@@ -102,9 +102,9 @@ class LikeController extends Controller
 
         // search order
         if ($order == 'new') {
-            $like_posts = $query->orderBy('posts.created_at', 'desc')->get();
+            $like_posts = $query->orderBy('posts.created_at', 'desc')->paginate(20);
         } else {
-            $like_posts = $query->orderBy('likes_count', 'desc')->get();
+            $like_posts = $query->orderBy('likes_count', 'desc')->paginate(20);
         }
         $posts = DB::table('posts')->count();
 

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -98,9 +98,9 @@ class PostController extends Controller
 
         // search order
         if ($order == 'new') {
-            $posts = $query->orderBy('posts.created_at', 'desc')->get();
+            $posts = $query->orderBy('posts.created_at', 'desc')->paginate(20);
         } else {
-            $posts = $query->orderBy('likes_count', 'desc')->get();
+            $posts = $query->orderBy('likes_count', 'desc')->paginate(20);
         }
 
 

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -18005,3 +18005,7 @@ a.text-dark:focus {
           appearance: none;
 }
 
+.top-wrapper .posts-wrapper .paginate_wrapper {
+  margin-top: 20px;
+}
+

--- a/resources/sass/posts/index.scss
+++ b/resources/sass/posts/index.scss
@@ -183,5 +183,8 @@
                 }
             }
         }
+        .paginate_wrapper {
+            margin-top: 20px;
+        }
     }
 }

--- a/resources/views/likes/index.blade.php
+++ b/resources/views/likes/index.blade.php
@@ -27,6 +27,9 @@
     @else
     <p>「{{ $keyword }}」に一致する記事は見つかりませんでした。</p>
     @endif
+    <div class="paginate_wrapper">
+      {{ $posts->links() }}
+    </div>
   </div>
 </div>
 @endsection

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -55,9 +55,13 @@
     </div>
     @if(count($posts) !== 0)
     @include('parts.posts_index')
+
     @else
     <p>「{{ $keyword }}」に一致する記事は見つかりませんでした。</p>
     @endif
+    <div class="paginate_wrapper">
+      {{ $posts->links() }}
+    </div>
   </div>
 </div>
 @endsection


### PR DESCRIPTION
# 目的
莫大な記事数になった際に、それらすべてを表示するのは処理負担が大きい。そのため、20記事ずつ表示をさせて負担を軽減することが目的となる。

# どうやって

## controller
get()で取得するのではなく、paginate()で記事を取得する。

下記のように変更前はgetで記述をしていたが、

```php
        // search order
        if ($order == 'new') {
            $posts = $query->orderBy('posts.created_at', 'desc')->get();
        } else {
            $posts = $query->orderBy('likes_count', 'desc')->get();
        }
```

これをpaginate()に変更する。

```php
        // search order
        if ($order == 'new') {
            $posts = $query->orderBy('posts.created_at', 'desc')->paginate(20);
        } else {
            $posts = $query->orderBy('likes_count', 'desc')->paginate(20);
        }
```

### 変更箇所
- PostController.php
- LikeController.php


## Blade
{{ $posts->likes() }}を追加し、次の20件の記事を取得できるようにする。

### 変更箇所
- index.blade.php of Posts
- index.blade.php of Likes