### PR TITLE
create.blade.php のタグに合わせて幅を調整

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -17475,8 +17475,11 @@ a.text-dark:focus {
   display: block;
 }
 
-.post-page-wrapper .post-create_wrapper .tag-wrapper {
-  display: block;
+.post-page-wrapper .post-create_wrapper .tags {
+  display: -moz-flex;
+  display: -ms-flex;
+  display: -o-flex;
+  display: flex;
   width: 100%;
   height: calc(1.6em + 0.75rem + 2px);
   padding: 0.375rem 0.75rem;
@@ -17492,11 +17495,11 @@ a.text-dark:focus {
   margin: 0;
 }
 
-.post-page-wrapper .post-create_wrapper .tag-wrapper li {
+.post-page-wrapper .post-create_wrapper .tags-wrapper li {
   display: inline;
 }
 
-.post-page-wrapper .post-create_wrapper .tag-wrapper .tag-content {
+.post-page-wrapper .post-create_wrapper .tags-wrapper .tag-content {
   background-color: #d9eafe;
   font-size: 12px;
   padding: 2px;
@@ -17505,11 +17508,11 @@ a.text-dark:focus {
   margin-right: 2px;
 }
 
-.post-page-wrapper .post-create_wrapper .tag-wrapper .tag-content .tag-label {
+.post-page-wrapper .post-create_wrapper .tags-wrapper .tag-content .tag-label {
   line-height: 12px;
 }
 
-.post-page-wrapper .post-create_wrapper .tag-wrapper .tag-new #tag-input {
+.post-page-wrapper .post-create_wrapper .tags-new #tag-input {
   border: none;
   outline: 0;
   width: 280px;

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -17512,10 +17512,10 @@ a.text-dark:focus {
   line-height: 12px;
 }
 
-.post-page-wrapper .post-create_wrapper .tags-new #tag-input {
+.post-page-wrapper .post-create_wrapper .tags #tag-input {
   border: none;
   outline: 0;
-  width: 280px;
+  width: 100%;
 }
 
 .post-page-wrapper .post-create_wrapper .markdown-wrapper {

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -17495,6 +17495,10 @@ a.text-dark:focus {
   margin: 0;
 }
 
+.post-page-wrapper .post-create_wrapper .tags-wrapper {
+  white-space: normal;
+}
+
 .post-page-wrapper .post-create_wrapper .tags-wrapper li {
   display: inline;
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -40034,6 +40034,7 @@ $(function () {
         }
 
         $tag.remove();
+        ul_width();
       }
     }
   }); //Delete tag
@@ -40048,6 +40049,7 @@ $(function () {
     }
 
     $tag.remove();
+    ul_width();
   });
 });
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -39995,6 +39995,8 @@ $(function () {
   $tags = [];
   $("#tag-input").on("keydown", function (e) {
     //add tag
+    $ul = $(".tags").find(".tags-wrapper");
+
     if (e.keyCode == 13) {
       var $text = this.value;
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -39992,6 +39992,16 @@ $(function () {
     return $tag_li;
   }
 
+  function ul_width() {
+    var ul_width = 0;
+    $(".tag-content").each(function () {
+      ul_width += $(this).outerWidth(true);
+    });
+    $("#tag-input").css({
+      width: "calc(100% - ".concat(ul_width, "px - 12px)")
+    });
+  }
+
   $tags = [];
   $("#tag-input").on("keydown", function (e) {
     //add tag
@@ -40004,17 +40014,7 @@ $(function () {
         $(".tags-wrapper").append(new_tag($text));
         $tags.push($text);
         this.value = "";
-        $ul = $(".tags-wrapper");
-        $lis = $ul.find(".tag-content");
-        var ul_width = 0;
-        $(".tag-content").each(function () {
-          ul_width += $(this).outerWidth(true);
-        });
-        $("#tag-input").css({
-          width: "calc(100% - ".concat(ul_width, "px - 12px)")
-        });
-        console.log(ul_width);
-        console.log($(".tags-wrapper").outerWidth());
+        ul_width();
       }
 
       return false;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -39988,7 +39988,7 @@ $(function () {
 
 $(function () {
   function new_tag(text) {
-    var $tag_li = "<li class=\"tag-content\">\n                    <span class=\"tag-label\">\n                      ".concat(text, "\n                    </span>\n                    <a class=\"text-icon\">\n                      \xD7\n                    </a>\n                    <input class=\"tag-hidden-field\" name=\"tags[]\" value=\"").concat(text, "\" type=\"hidden\">\n                  </li>");
+    var $tag_li = "<li class=\"tag-content\">\n                    <span class=\"tag-label\">\n                      ".concat(text, "\n                      <a class=\"text-icon\">\n                        \xD7\n                      </a>\n                    </span>\n                    <input class=\"tag-hidden-field\" name=\"tags[]\" value=\"").concat(text, "\" type=\"hidden\">\n                  </li>");
     return $tag_li;
   }
 
@@ -40004,7 +40004,17 @@ $(function () {
         $(".tags-wrapper").append(new_tag($text));
         $tags.push($text);
         this.value = "";
-        $ul_width = $ul.outerWidth();
+        $ul = $(".tags-wrapper");
+        $lis = $ul.find(".tag-content");
+        var ul_width = 0;
+        $(".tag-content").each(function () {
+          ul_width += $(this).outerWidth(true);
+        });
+        $("#tag-input").css({
+          width: "calc(100% - ".concat(ul_width, "px - 12px)")
+        });
+        console.log(ul_width);
+        console.log($(".tags-wrapper").outerWidth());
       }
 
       return false;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -40004,6 +40004,7 @@ $(function () {
         $(".tags-wrapper").append(new_tag($text));
         $tags.push($text);
         this.value = "";
+        $ul_width = $ul.outerWidth();
       }
 
       return false;

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -39987,24 +39987,26 @@ $(function () {
 /***/ (function(module, exports) {
 
 $(function () {
-  function add_tag(text) {
+  function new_tag(text) {
     var $tag_li = "<li class=\"tag-content\">\n                    <span class=\"tag-label\">\n                      ".concat(text, "\n                    </span>\n                    <a class=\"text-icon\">\n                      \xD7\n                    </a>\n                    <input class=\"tag-hidden-field\" name=\"tags[]\" value=\"").concat(text, "\" type=\"hidden\">\n                  </li>");
     return $tag_li;
   }
 
   $tags = [];
   $("#tag-input").on("keydown", function (e) {
+    //new tag 
     if (e.keyCode == 13) {
       var $text = this.value;
 
       if ($text.length > 0 && $tags.indexOf($text) == -1) {
-        $("#tag-input").before(add_tag($text));
+        $("#tag-input").before(new_tag($text));
         $tags.push($text);
         this.value = "";
       }
 
       return false;
-    }
+    } //Delete tag 
+
 
     if (e.keyCode == 8) {
       var $text = this.value;
@@ -40021,7 +40023,8 @@ $(function () {
         $tag.remove();
       }
     }
-  });
+  }); //Delete tag 
+
   $(".tag-wrapper").on("click", ".text-icon", function () {
     var $tag = $(this).parents(".tag-content");
     var tag_value = $tag.find(".tag-hidden-field").val();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -39994,18 +39994,18 @@ $(function () {
 
   $tags = [];
   $("#tag-input").on("keydown", function (e) {
-    //new tag 
+    //add tag
     if (e.keyCode == 13) {
       var $text = this.value;
 
       if ($text.length > 0 && $tags.indexOf($text) == -1) {
-        $("#tag-input").before(new_tag($text));
+        $(".tags-wrapper").append(new_tag($text));
         $tags.push($text);
         this.value = "";
       }
 
       return false;
-    } //Delete tag 
+    } //Delete tag
 
 
     if (e.keyCode == 8) {
@@ -40023,9 +40023,9 @@ $(function () {
         $tag.remove();
       }
     }
-  }); //Delete tag 
+  }); //Delete tag
 
-  $(".tag-wrapper").on("click", ".text-icon", function () {
+  $(".tags-wrapper").on("click", ".text-icon", function () {
     var $tag = $(this).parents(".tag-content");
     var tag_value = $tag.find(".tag-hidden-field").val();
     var index = $tags.indexOf(tag_value);

--- a/resources/js/create-tag.js
+++ b/resources/js/create-tag.js
@@ -12,6 +12,16 @@ $(function() {
         return $tag_li;
     }
 
+    function ul_width() {
+        var ul_width = 0;
+        $(".tag-content").each(function() {
+            ul_width += $(this).outerWidth(true);
+        });
+        $("#tag-input").css({
+            width: `calc(100% - ${ul_width}px - 12px)`
+        });
+    }
+
     $tags = [];
 
     $("#tag-input").on("keydown", function(e) {
@@ -23,18 +33,7 @@ $(function() {
                 $(".tags-wrapper").append(new_tag($text));
                 $tags.push($text);
                 this.value = "";
-                $ul = $(".tags-wrapper");
-                $lis = $ul.find(".tag-content");
-                var ul_width = 0;
-                $(".tag-content").each(function() {
-                    ul_width += $(this).outerWidth(true);
-                });
-
-                $("#tag-input").css({
-                    width: `calc(100% - ${ul_width}px - 12px)`
-                });
-                console.log(ul_width);
-                console.log($(".tags-wrapper").outerWidth());
+                ul_width();
             }
 
             return false;

--- a/resources/js/create-tag.js
+++ b/resources/js/create-tag.js
@@ -15,19 +15,18 @@ $(function() {
     $tags = [];
 
     $("#tag-input").on("keydown", function(e) {
-        
-        //new tag 
+        //add tag
         if (e.keyCode == 13) {
             var $text = this.value;
             if ($text.length > 0 && $tags.indexOf($text) == -1) {
-                $("#tag-input").before(new_tag($text));
+                $(".tags-wrapper").append(new_tag($text));
                 $tags.push($text);
                 this.value = "";
             }
             return false;
         }
 
-        //Delete tag 
+        //Delete tag
         if (e.keyCode == 8) {
             var $text = this.value;
             if ($text.length == 0) {
@@ -42,8 +41,8 @@ $(function() {
         }
     });
 
-   //Delete tag 
-    $(".tag-wrapper").on("click", ".text-icon", function() {
+    //Delete tag
+    $(".tags-wrapper").on("click", ".text-icon", function() {
         var $tag = $(this).parents(".tag-content");
         var tag_value = $tag.find(".tag-hidden-field").val();
         var index = $tags.indexOf(tag_value);

--- a/resources/js/create-tag.js
+++ b/resources/js/create-tag.js
@@ -16,6 +16,7 @@ $(function() {
 
     $("#tag-input").on("keydown", function(e) {
         //add tag
+        $ul = $(".tags").find(".tags-wrapper");
         if (e.keyCode == 13) {
             var $text = this.value;
             if ($text.length > 0 && $tags.indexOf($text) == -1) {

--- a/resources/js/create-tag.js
+++ b/resources/js/create-tag.js
@@ -50,6 +50,7 @@ $(function() {
                     $tags.splice(index, 1);
                 }
                 $tag.remove();
+                ul_width();
             }
         }
     });
@@ -63,5 +64,6 @@ $(function() {
             $tags.splice(index, 1);
         }
         $tag.remove();
+        ul_width();
     });
 });

--- a/resources/js/create-tag.js
+++ b/resources/js/create-tag.js
@@ -1,5 +1,5 @@
 $(function() {
-    function add_tag(text) {
+    function new_tag(text) {
         var $tag_li = `<li class="tag-content">
                     <span class="tag-label">
                       ${text}
@@ -15,16 +15,19 @@ $(function() {
     $tags = [];
 
     $("#tag-input").on("keydown", function(e) {
+        
+        //new tag 
         if (e.keyCode == 13) {
             var $text = this.value;
             if ($text.length > 0 && $tags.indexOf($text) == -1) {
-                $("#tag-input").before(add_tag($text));
+                $("#tag-input").before(new_tag($text));
                 $tags.push($text);
                 this.value = "";
             }
             return false;
         }
 
+        //Delete tag 
         if (e.keyCode == 8) {
             var $text = this.value;
             if ($text.length == 0) {
@@ -39,6 +42,7 @@ $(function() {
         }
     });
 
+   //Delete tag 
     $(".tag-wrapper").on("click", ".text-icon", function() {
         var $tag = $(this).parents(".tag-content");
         var tag_value = $tag.find(".tag-hidden-field").val();

--- a/resources/js/create-tag.js
+++ b/resources/js/create-tag.js
@@ -23,6 +23,7 @@ $(function() {
                 $(".tags-wrapper").append(new_tag($text));
                 $tags.push($text);
                 this.value = "";
+                $ul_width = $ul.outerWidth();
             }
             return false;
         }

--- a/resources/js/create-tag.js
+++ b/resources/js/create-tag.js
@@ -3,10 +3,10 @@ $(function() {
         var $tag_li = `<li class="tag-content">
                     <span class="tag-label">
                       ${text}
+                      <a class="text-icon">
+                        ×
+                      </a>
                     </span>
-                    <a class="text-icon">
-                      ×
-                    </a>
                     <input class="tag-hidden-field" name="tags[]" value="${text}" type="hidden">
                   </li>`;
         return $tag_li;
@@ -23,8 +23,20 @@ $(function() {
                 $(".tags-wrapper").append(new_tag($text));
                 $tags.push($text);
                 this.value = "";
-                $ul_width = $ul.outerWidth();
+                $ul = $(".tags-wrapper");
+                $lis = $ul.find(".tag-content");
+                var ul_width = 0;
+                $(".tag-content").each(function() {
+                    ul_width += $(this).outerWidth(true);
+                });
+
+                $("#tag-input").css({
+                    width: `calc(100% - ${ul_width}px - 12px)`
+                });
+                console.log(ul_width);
+                console.log($(".tags-wrapper").outerWidth());
             }
+
             return false;
         }
 

--- a/resources/sass/posts/create.scss
+++ b/resources/sass/posts/create.scss
@@ -42,12 +42,10 @@
                     }
                 }
             }
-            &-new {
-                #tag-input {
-                    border: none;
-                    outline: 0;
-                    width: 280px;
-                }
+            #tag-input {
+                border: none;
+                outline: 0;
+                width: 100%;
             }
         }
         .markdown-wrapper {

--- a/resources/sass/posts/create.scss
+++ b/resources/sass/posts/create.scss
@@ -5,10 +5,13 @@
     .post-create_wrapper {
         width: 100%;
         height: calc(100% - 56px);
-
         display: block;
-        .tag-wrapper {
-            display: block;
+        .tags {
+            display: -webkit-flex;
+            display: -moz-flex;
+            display: -ms-flex;
+            display: -o-flex;
+            display: flex;
             width: 100%;
             height: calc(1.6em + 0.75rem + 2px);
             padding: 0.375rem 0.75rem;
@@ -23,21 +26,23 @@
             transition: border-color 0.15s ease-in-out,
                 box-shadow 0.15s ease-in-out;
             margin: 0;
-            li {
-                display: inline;
-            }
-            .tag-content {
-                background-color: rgb(217, 234, 254);
-                font-size: 12px;
-                padding: 2px;
-                border-radius: 3px;
-                line-height: 100%;
-                margin-right: 2px;
-                .tag-label {
-                    line-height: 12px;
+            &-wrapper {
+                li {
+                    display: inline;
+                }
+                .tag-content {
+                    background-color: rgb(217, 234, 254);
+                    font-size: 12px;
+                    padding: 2px;
+                    border-radius: 3px;
+                    line-height: 100%;
+                    margin-right: 2px;
+                    .tag-label {
+                        line-height: 12px;
+                    }
                 }
             }
-            .tag-new {
+            &-new {
                 #tag-input {
                     border: none;
                     outline: 0;

--- a/resources/sass/posts/create.scss
+++ b/resources/sass/posts/create.scss
@@ -27,6 +27,7 @@
                 box-shadow 0.15s ease-in-out;
             margin: 0;
             &-wrapper {
+                white-space: normal;
                 li {
                     display: inline;
                 }

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -6,8 +6,8 @@
   <div class="post-create_wrapper">
     <input type="text" class="form-control" id="title-input" placeholder="タイトル" name="title">
     <div class="tags">
-      <ul class="tag-wrapper"></ul>
-      <div class="tag-new">
+      <ul class="tags-wrapper"></ul>
+      <div class="tags-new">
         <input id="tag-input" name="tags[]" class="tag-input" placeholder="プログラミング技術に関するタグを入力" type="text" />
       </div>
     </div>

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -7,7 +7,7 @@
     <input type="text" class="form-control" id="title-input" placeholder="タイトル" name="title">
     <div class="tags">
       <ul class="tags-wrapper"></ul>
-      <input id="tag-input" name="tags[]" class="tag-input" placeholder="プログラミング技術に関するタグを入力" type="text" />
+      <input id="tag-input" name="tags[]" placeholder="プログラミング技術に関するタグを入力" type="text" />
     </div>
     <div class="markdown-wrapper">
       <div class="markdown">

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -7,9 +7,7 @@
     <input type="text" class="form-control" id="title-input" placeholder="タイトル" name="title">
     <div class="tags">
       <ul class="tags-wrapper"></ul>
-      <div class="tags-new">
-        <input id="tag-input" name="tags[]" class="tag-input" placeholder="プログラミング技術に関するタグを入力" type="text" />
-      </div>
+      <input id="tag-input" name="tags[]" class="tag-input" placeholder="プログラミング技術に関するタグを入力" type="text" />
     </div>
     <div class="markdown-wrapper">
       <div class="markdown">

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -6,9 +6,9 @@
   <div class="post-create_wrapper">
     <input type="text" class="form-control" id="title-input" placeholder="タイトル" name="title">
     <ul class="tag-wrapper">
-      <li class="tag-new">
+      <div class="tag-new">
         <input id="tag-input" name="tags[]" class="tag-input" placeholder="プログラミング技術に関するタグを入力" type="text" />
-      </li>
+      </div>
     </ul>
     <div class="markdown-wrapper">
       <div class="markdown">

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -5,11 +5,12 @@
   @csrf
   <div class="post-create_wrapper">
     <input type="text" class="form-control" id="title-input" placeholder="タイトル" name="title">
-    <ul class="tag-wrapper">
+    <div class="tags">
+      <ul class="tag-wrapper"></ul>
       <div class="tag-new">
         <input id="tag-input" name="tags[]" class="tag-input" placeholder="プログラミング技術に関するタグを入力" type="text" />
       </div>
-    </ul>
+    </div>
     <div class="markdown-wrapper">
       <div class="markdown">
         <textarea name="body" id="markdown_editor_textarea" placeholder="プログラミング知識をmarkdonw記法で書いて共有" cols="30" rows="10"></textarea>


### PR DESCRIPTION
#What
タグが増えるにつれて、id(tag-input)の幅を調整させる。
これまでは一定のwidthであったが、そうではなくwidth: 100%;からタグliの幅合計を除いたwidthに変更させる。
これにより、よりタグ入力しやすい。