### PR TITLE
セッションで検索処理のコードの短縮

### DIFF
--- a/app/Http/Controllers/LikeController.php
+++ b/app/Http/Controllers/LikeController.php
@@ -24,9 +24,9 @@ class LikeController extends Controller
         $order = $request->input('order');
         $lgtm_min = $request->input('lgtm-min');
         $lgtm_max = $request->input('lgtm-max');
-        $priod = $request->input('priod');
-        $priod_start = $request->input('piriod-start');
-        $priod_end = $request->input('piriod-end');
+        $period = $request->input('period');
+        $period_start = $request->input('period-start');
+        $period_end = $request->input('period-end');
 
 
         // keyword
@@ -35,14 +35,14 @@ class LikeController extends Controller
             $keyword = "#{$tag_btn_value}";
         }
 
-        // query
+        // queryp
         $query = Post::withCount('likes')
             ->join('likes', 'posts.id', '=', 'likes.post_id')
             ->where('likes.user_id', '=', Auth::id());
-        $posts = DetailedSearch::DetailedSearch($query, $lgtm_min, $lgtm_max, $priod, $priod_start, $priod_end, $keyword, $order);
+        $posts = DetailedSearch::DetailedSearch($query, $lgtm_min, $lgtm_max, $period, $period_start, $period_end, $keyword, $order);
         $all_posts_count = DB::table('posts')->count();
 
-        return view('likes.index', compact('posts', 'all_posts_count', 'keyword', 'order', 'lgtm_min', 'lgtm_max', 'priod', 'priod_start', 'priod_end', 'tag_btn_value'));
+        return view('likes.index', compact('posts', 'all_posts_count', 'keyword', 'order', 'lgtm_min', 'lgtm_max', 'period', 'period_start', 'period_end', 'tag_btn_value'));
     }
 
     /**

--- a/app/Http/Controllers/LikeController.php
+++ b/app/Http/Controllers/LikeController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\User;
 use App\Models\like;
 use App\Models\post;
 use Illuminate\Http\Request;
@@ -21,13 +20,7 @@ class LikeController extends Controller
     {
         // values
         $tag_btn_value = $request->input('tag_btn');
-        $order = $request->input('order');
-        $lgtm_min = $request->input('lgtm-min');
-        $lgtm_max = $request->input('lgtm-max');
-        $period = $request->input('period');
-        $period_start = $request->input('period-start');
-        $period_end = $request->input('period-end');
-
+        $all_posts_count = DB::table('posts')->count();
 
         // keyword
         $keyword = $request->input('search');
@@ -35,14 +28,14 @@ class LikeController extends Controller
             $keyword = "#{$tag_btn_value}";
         }
 
-        // queryp
+        // query
         $query = Post::withCount('likes')
             ->join('likes', 'posts.id', '=', 'likes.post_id')
             ->where('likes.user_id', '=', Auth::id());
-        $posts = DetailedSearch::DetailedSearch($query, $lgtm_min, $lgtm_max, $period, $period_start, $period_end, $keyword, $order);
+        $posts = DetailedSearch::DetailedSearch($query, $keyword, $request);
         $all_posts_count = DB::table('posts')->count();
 
-        return view('likes.index', compact('posts', 'all_posts_count', 'keyword', 'order', 'lgtm_min', 'lgtm_max', 'period', 'period_start', 'period_end', 'tag_btn_value'));
+        return view('likes.index', compact('posts', 'all_posts_count', 'keyword'));
     }
 
     /**

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -31,21 +31,14 @@ class PostController extends Controller
         // query
         $query = Post::withCount('likes');
         $posts = DetailedSearch::DetailedSearch($query, $keyword, $request);
-        return view('posts.index', compact('all_posts_count', 'posts', 'keyword'));
+        return view('posts.index', compact('posts', 'all_posts_count', 'keyword'));
     }
 
     public function my_posts(Request $request)
     {
         // values
         $tag_btn_value = $request->input('tag_btn');
-        $order = $request->input('order');
-        $lgtm_min = $request->input('lgtm-min');
-        $lgtm_max = $request->input('lgtm-max');
-        $period = $request->input('period');
-        $period_start = $request->input('period-start');
-        $period_end = $request->input('period-end');
         $all_posts_count = DB::table('posts')->count();
-
 
         // keyword
         $keyword = $request->input('search');
@@ -56,8 +49,8 @@ class PostController extends Controller
 
         // query
         $query = Post::where("posts.user_id", "=", Auth::user()->id)->withCount('likes');
-        $posts = DetailedSearch::DetailedSearch($query, $lgtm_min, $lgtm_max, $period, $period_start, $period_end, $keyword, $order);
-        return view('posts.my_posts', compact('posts', 'all_posts_count', 'keyword', 'order', 'lgtm_min', 'lgtm_max', 'period', 'period_start', 'period_end', 'tag_btn_value'));
+        $posts = DetailedSearch::DetailedSearch($query, $keyword, $request);
+        return view('posts.my_posts', compact('posts', 'all_posts_count', 'keyword'));
     }
 
     /**

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -30,6 +30,9 @@ class PostController extends Controller
 
         //settion
         $request->session()->put('order', $request->input('order'));
+        $request->session()->put('lgtm-min', $request->input('lgtm-min'));
+        $request->session()->put('lgtm-max', $request->input('lgtm-max'));
+        $request->session()->put('priod', $request->input('priod'));
 
         // keyword
         $keyword = $request->input('search');

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -28,6 +28,9 @@ class PostController extends Controller
         $priod_end = $request->input('piriod-end');
         $all_posts_count = DB::table('posts')->count();
 
+        //settion
+        $request->session()->put('order', $request->input('order'));
+
         // keyword
         $keyword = $request->input('search');
         if ($tag_btn_value !== null) {

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -20,25 +20,7 @@ class PostController extends Controller
     {
         // values
         $tag_btn_value = $request->input('tag_btn');
-        $order = $request->input('order');
-        $lgtm_min = $request->input('lgtm-min');
-        $lgtm_max = $request->input('lgtm-max');
-        $period = $request->input('period');
-        $period_start = $request->input('period-start');
-        $period_end = $request->input('period-end');
         $all_posts_count = DB::table('posts')->count();
-
-        //settion
-        $request->session()->put('order', $request->input('order'));
-        $request->session()->put('lgtm-min', $request->input('lgtm-min'));
-        $request->session()->put('lgtm-max', $request->input('lgtm-max'));
-        $request->session()->put('period', $request->input('period'));
-        if ($request->input('period') == "period"){
-            $request->session()->put('period-start', $request->input('period-start'));
-            $request->session()->put('period-end', $request->input('period'));
-        } else {
-            $request->session()->forget(['period-start', 'period-end']);
-        }
 
         // keyword
         $keyword = $request->input('search');
@@ -48,8 +30,8 @@ class PostController extends Controller
 
         // query
         $query = Post::withCount('likes');
-        $posts = DetailedSearch::DetailedSearch($query, $lgtm_min, $lgtm_max, $period, $period_start, $period_end, $keyword, $order);
-        return view('posts.index', compact('all_posts_count', 'posts', 'keyword', 'order', 'lgtm_min', 'lgtm_max', 'period', 'period_start', 'period_end', 'tag_btn_value'));
+        $posts = DetailedSearch::DetailedSearch($query, $keyword, $request);
+        return view('posts.index', compact('all_posts_count', 'posts', 'keyword'));
     }
 
     public function my_posts(Request $request)

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -23,16 +23,16 @@ class PostController extends Controller
         $order = $request->input('order');
         $lgtm_min = $request->input('lgtm-min');
         $lgtm_max = $request->input('lgtm-max');
-        $priod = $request->input('priod');
-        $priod_start = $request->input('piriod-start');
-        $priod_end = $request->input('piriod-end');
+        $period = $request->input('period');
+        $period_start = $request->input('piriod-start');
+        $period_end = $request->input('piriod-end');
         $all_posts_count = DB::table('posts')->count();
 
         //settion
         $request->session()->put('order', $request->input('order'));
         $request->session()->put('lgtm-min', $request->input('lgtm-min'));
         $request->session()->put('lgtm-max', $request->input('lgtm-max'));
-        $request->session()->put('priod', $request->input('priod'));
+        $request->session()->put('period', $request->input('period'));
 
         // keyword
         $keyword = $request->input('search');
@@ -42,8 +42,8 @@ class PostController extends Controller
 
         // query
         $query = Post::withCount('likes');
-        $posts = DetailedSearch::DetailedSearch($query, $lgtm_min, $lgtm_max, $priod, $priod_start, $priod_end, $keyword, $order);
-        return view('posts.index', compact('all_posts_count', 'posts', 'keyword', 'order', 'lgtm_min', 'lgtm_max', 'priod', 'priod_start', 'priod_end', 'tag_btn_value'));
+        $posts = DetailedSearch::DetailedSearch($query, $lgtm_min, $lgtm_max, $period, $period_start, $period_end, $keyword, $order);
+        return view('posts.index', compact('all_posts_count', 'posts', 'keyword', 'order', 'lgtm_min', 'lgtm_max', 'period', 'period_start', 'period_end', 'tag_btn_value'));
     }
 
     public function my_posts(Request $request)
@@ -53,9 +53,9 @@ class PostController extends Controller
         $order = $request->input('order');
         $lgtm_min = $request->input('lgtm-min');
         $lgtm_max = $request->input('lgtm-max');
-        $priod = $request->input('priod');
-        $priod_start = $request->input('piriod-start');
-        $priod_end = $request->input('piriod-end');
+        $period = $request->input('period');
+        $period_start = $request->input('period-start');
+        $period_end = $request->input('period-end');
         $all_posts_count = DB::table('posts')->count();
 
 
@@ -68,8 +68,8 @@ class PostController extends Controller
 
         // query
         $query = Post::where("posts.user_id", "=", Auth::user()->id)->withCount('likes');
-        $posts = DetailedSearch::DetailedSearch($query, $lgtm_min, $lgtm_max, $priod, $priod_start, $priod_end, $keyword, $order);
-        return view('posts.my_posts', compact('posts', 'all_posts_count', 'keyword', 'order', 'lgtm_min', 'lgtm_max', 'priod', 'priod_start', 'priod_end', 'tag_btn_value'));
+        $posts = DetailedSearch::DetailedSearch($query, $lgtm_min, $lgtm_max, $period, $period_start, $period_end, $keyword, $order);
+        return view('posts.my_posts', compact('posts', 'all_posts_count', 'keyword', 'order', 'lgtm_min', 'lgtm_max', 'period', 'period_start', 'period_end', 'tag_btn_value'));
     }
 
     /**

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -24,8 +24,8 @@ class PostController extends Controller
         $lgtm_min = $request->input('lgtm-min');
         $lgtm_max = $request->input('lgtm-max');
         $period = $request->input('period');
-        $period_start = $request->input('piriod-start');
-        $period_end = $request->input('piriod-end');
+        $period_start = $request->input('period-start');
+        $period_end = $request->input('period-end');
         $all_posts_count = DB::table('posts')->count();
 
         //settion
@@ -33,6 +33,12 @@ class PostController extends Controller
         $request->session()->put('lgtm-min', $request->input('lgtm-min'));
         $request->session()->put('lgtm-max', $request->input('lgtm-max'));
         $request->session()->put('period', $request->input('period'));
+        if ($request->input('period') == "period"){
+            $request->session()->put('period-start', $request->input('period-start'));
+            $request->session()->put('period-end', $request->input('period'));
+        } else {
+            $request->session()->forget(['period-start', 'period-end']);
+        }
 
         // keyword
         $keyword = $request->input('search');

--- a/app/Services/DetailedSearch.php
+++ b/app/Services/DetailedSearch.php
@@ -2,12 +2,31 @@
 
 namespace App\Services;
 
-use Illuminate\Support\Facades\DB;
-
 class DetailedSearch
 {
-  public static function DetailedSearch($query, $lgtm_min, $lgtm_max, $period, $period_start, $period_end, $keyword, $order)
+  public static function DetailedSearch($query, $keyword, $request)
   {
+    // values
+    $order = $request->input('order');
+    $lgtm_min = $request->input('lgtm-min');
+    $lgtm_max = $request->input('lgtm-max');
+    $period = $request->input('period');
+    $period_start = $request->input('period-start');
+    $period_end = $request->input('period-end');
+
+    //settion
+    $request->session()->put('order', $request->input('order'));
+    $request->session()->put('lgtm-min', $request->input('lgtm-min'));
+    $request->session()->put('lgtm-max', $request->input('lgtm-max'));
+    $request->session()->put('period', $request->input('period'));
+    if ($request->input('period') == "period") {
+      $request->session()->put('period-start', $request->input('period-start'));
+      $request->session()->put('period-end', $request->input('period'));
+    } else {
+      $request->session()->forget(['period-start', 'period-end']);
+    }
+
+    //keyword
     $keyword_space_half = mb_convert_kana($keyword, 's');
     $keywords = preg_split('/[\s]+/', $keyword_space_half);
     preg_match_all('/#([a-zA-z0-9０-９ぁ-んァ-ヶ亜-熙]+)/u', $keyword, $match);

--- a/app/Services/DetailedSearch.php
+++ b/app/Services/DetailedSearch.php
@@ -21,7 +21,7 @@ class DetailedSearch
     $request->session()->put('period', $request->input('period'));
     if ($request->input('period') == "period") {
       $request->session()->put('period-start', $request->input('period-start'));
-      $request->session()->put('period-end', $request->input('period'));
+      $request->session()->put('period-end', $request->input('period-end'));
     } else {
       $request->session()->forget(['period-start', 'period-end']);
     }

--- a/app/Services/DetailedSearch.php
+++ b/app/Services/DetailedSearch.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\DB;
 
 class DetailedSearch
 {
-  public static function DetailedSearch($query, $lgtm_min, $lgtm_max, $priod, $priod_start, $priod_end, $keyword, $order)
+  public static function DetailedSearch($query, $lgtm_min, $lgtm_max, $period, $period_start, $period_end, $keyword, $order)
   {
     $keyword_space_half = mb_convert_kana($keyword, 's');
     $keywords = preg_split('/[\s]+/', $keyword_space_half);
@@ -22,9 +22,9 @@ class DetailedSearch
       $query->having('likes_count', '<=', $lgtm_max);
     }
 
-    // priod search
-    if ($priod !== null) {
-      switch ($priod) {
+    // period search
+    if ($period !== null) {
+      switch ($period) {
         case "day":
           $query->where([
             ['posts.created_at', '>=', date("Y-m-d 00:00:00")],
@@ -42,8 +42,8 @@ class DetailedSearch
           ]);
         case "period":
           $query->where([
-            ['posts.created_at', '>=', date("{$priod_start} 00:00:00")],
-            ['posts.created_at', '<=', date("{$priod_end} 23:59:59")]
+            ['posts.created_at', '>=', date("{$period_start} 00:00:00")],
+            ['posts.created_at', '<=', date("{$period_end} 23:59:59")]
           ]);
       }
     }

--- a/readme.md
+++ b/readme.md
@@ -158,9 +158,9 @@ public function index(Request $request)
         $order = $request->input('order');
         $lgtm_min = $request->input('lgtm-min');
         $lgtm_max = $request->input('lgtm-max');
-        $priod = $request->input('priod');
-        $priod_start = $request->input('piriod-start');
-        $priod_end = $request->input('piriod-end');
+        $period = $request->input('period');
+        $period_start = $request->input('period-start');
+        $period_end = $request->input('period-end');
 
 
         // keyword
@@ -183,9 +183,9 @@ public function index(Request $request)
             $query->having('likes_count', '>=', $lgtm_max);
         }
 
-        // priod search
-        if ($priod !== null) {
-            switch ($priod) {
+        // period search
+        if ($period !== null) {
+            switch ($period) {
                 case "day":
                     $query->where([
                         ['posts.created_at', '>=', date("Y-m-d 00:00:00")],
@@ -203,8 +203,8 @@ public function index(Request $request)
                     ]);
                 case "period":
                     $query->where([
-                        ['posts.created_at', '>=', date("{$priod_start} 00:00:00")],
-                        ['posts.created_at', '<=', date("{$priod_end} 23:59:59")]
+                        ['posts.created_at', '>=', date("{$period_start} 00:00:00")],
+                        ['posts.created_at', '<=', date("{$period_end} 23:59:59")]
                     ]);
             }
         }
@@ -253,9 +253,9 @@ public function index(Request $request)
         $order = $request->input('order');
         $lgtm_min = $request->input('lgtm-min');
         $lgtm_max = $request->input('lgtm-max');
-        $priod = $request->input('priod');
-        $priod_start = $request->input('piriod-start');
-        $priod_end = $request->input('piriod-end');
+        $period = $request->input('period');
+        $period_start = $request->input('period-start');
+        $period_end = $request->input('period-end');
         $all_posts_count = DB::table('posts')->count();
 
         // keyword
@@ -266,8 +266,8 @@ public function index(Request $request)
 
         // query
         $query = Post::withCount('likes');
-        $posts = DetailedSearch::DetailedSearch($query, $lgtm_min, $lgtm_max, $priod, $priod_start, $priod_end, $keyword, $order);
-        return view('posts.index', compact('all_posts_count', 'posts', 'keyword', 'order', 'lgtm_min', 'lgtm_max', 'priod', 'priod_start', 'priod_end', 'tag_btn_value'));
+        $posts = DetailedSearch::DetailedSearch($query, $lgtm_min, $lgtm_max, $period, $period_start, $period_end, $keyword, $order);
+        return view('posts.index', compact('all_posts_count', 'posts', 'keyword', 'order', 'lgtm_min', 'lgtm_max', 'period', 'period_start', 'period_end', 'tag_btn_value'));
     }
 ```
 
@@ -374,9 +374,9 @@ if ($order == 'new') {
 記事の投稿日を`posts.created_at`で取得し、date関数を利用して絞り込みを実施している。
 
 ```php
-        // priod search
-        if ($priod !== null) {
-            switch ($priod) {
+        // period search
+        if ($period !== null) {
+            switch ($period) {
                 case "day":
                     $query->where([
                         ['posts.created_at', '>=', date("Y-m-d 00:00:00")],
@@ -394,8 +394,8 @@ if ($order == 'new') {
                     ]);
                 case "period":
                     $query->where([
-                        ['posts.created_at', '>=', date("{$priod_start} 00:00:00")],
-                        ['posts.created_at', '<=', date("{$priod_end} 23:59:59")]
+                        ['posts.created_at', '>=', date("{$period_start} 00:00:00")],
+                        ['posts.created_at', '<=', date("{$period_end} 23:59:59")]
                     ]);
             }
         }

--- a/resources/views/parts/detaile-search.blade.php
+++ b/resources/views/parts/detaile-search.blade.php
@@ -93,9 +93,9 @@
               <span>
                 <label for="">
                   @if($period_end !== null)
-                  終了:<input type="date" class="input-small" name="piriod-end" placeholder="2020-02-11" value="{{$period_end}}">
+                  終了:<input type="date" class="input-small" name="period-end" placeholder="2020-02-11" value="{{$period_end}}">
                   @else
-                  終了:<input type="date" class="input-small" name="piriod-end" placeholder="2020-02-11">
+                  終了:<input type="date" class="input-small" name="period-end" placeholder="2020-02-11">
                   @endif
                 </label>
               </span>

--- a/resources/views/parts/detaile-search.blade.php
+++ b/resources/views/parts/detaile-search.blade.php
@@ -32,7 +32,7 @@
             <div>
               <span class="search-conditions_title order-terms_title">順番</span>
             </div>
-            @if($order == "new")
+            @if(Session::has('order') && Session::get('order') == "new")
             <div class="search-conditions_radio">
               <input type="radio" name="order" value="lgtm">LGTM数順
             </div>

--- a/resources/views/parts/detaile-search.blade.php
+++ b/resources/views/parts/detaile-search.blade.php
@@ -83,8 +83,8 @@
             <div class="search-conditions_radio">
               <span>
                 <label for="">
-                  @if($period_start !== null)
-                  開始:<input type="date" class="input-small" name="period-start" placeholder="2020-01-11" value="{{$period_start}}">
+                  @if(Session::has('period-start') && Session::get('period-start') !== null)
+                  開始:<input type="date" class="input-small" name="period-start" placeholder="2020-01-11" value="{{Session::get('period-start')}}">
                   @else
                   開始:<input type="date" class="input-small" name="period-start" placeholder="2020-01-11">
                   @endif
@@ -92,8 +92,8 @@
               </span>
               <span>
                 <label for="">
-                  @if($period_end !== null)
-                  終了:<input type="date" class="input-small" name="period-end" placeholder="2020-02-11" value="{{$period_end}}">
+                  @if(Session::has('period-end') && Session::get('period-end') !== null)
+                  終了:<input type="date" class="input-small" name="period-end" placeholder="2020-02-11" value="{{Session::get('period-end')}}">
                   @else
                   終了:<input type="date" class="input-small" name="period-end" placeholder="2020-02-11">
                   @endif

--- a/resources/views/parts/detaile-search.blade.php
+++ b/resources/views/parts/detaile-search.blade.php
@@ -53,47 +53,47 @@
               <span class="search-conditions_title">期間</span>
             </div>
             <div class="search-conditions_radio">
-              @if(Session::has('priod') && Session::get('priod') == "day")
-              <input type="radio" name="priod" value="day" checked="checked">1日
+              @if(Session::has('period') && Session::get('period') == "day")
+              <input type="radio" name="period" value="day" checked="checked">1日
               @else
-              <input type="radio" name="priod" value="day">1日
+              <input type="radio" name="period" value="day">1日
               @endif
             </div>
             <div class="search-conditions_radio">
-              @if(Session::has('priod') && Session::get('priod') == "week")
-              <input type="radio" name="priod" value="week" checked="checked">1週間
+              @if(Session::has('period') && Session::get('period') == "week")
+              <input type="radio" name="period" value="week" checked="checked">1週間
               @else
-              <input type="radio" name="priod" value="week">1週間
+              <input type="radio" name="period" value="week">1週間
               @endif
             </div>
             <div class="search-conditions_radio">
-              @if(Session::has('priod') && Session::get('priod') == "month")
-              <input type="radio" name="priod" value="month" checked="checked">1月間
+              @if(Session::has('period') && Session::get('period') == "month")
+              <input type="radio" name="period" value="month" checked="checked">1月間
               @else
-              <input type="radio" name="priod" value="month">1月間
+              <input type="radio" name="period" value="month">1月間
               @endif
             </div>
             <div class="search-conditions_radio">
-              @if(Settion::has('priod') && Settion::get('priod') == "period")
-              <input type="radio" name="priod" value="period" checked="checked">期間指定
+              @if(Settion::has('period') && Settion::get('period') == "period")
+              <input type="radio" name="period" value="period" checked="checked">期間指定
               @else
-              <input type="radio" name="priod" value="period">期間指定
+              <input type="radio" name="period" value="period">期間指定
               @endif
             </div>
             <div class="search-conditions_radio">
               <span>
                 <label for="">
-                  @if($priod_start !== null)
-                  開始:<input type="date" class="input-small" name="piriod-start" placeholder="2020-01-11" value="{{$priod_start}}">
+                  @if($period_start !== null)
+                  開始:<input type="date" class="input-small" name="period-start" placeholder="2020-01-11" value="{{$period_start}}">
                   @else
-                  開始:<input type="date" class="input-small" name="piriod-start" placeholder="2020-01-11">
+                  開始:<input type="date" class="input-small" name="period-start" placeholder="2020-01-11">
                   @endif
                 </label>
               </span>
               <span>
                 <label for="">
-                  @if($priod_end !== null)
-                  終了:<input type="date" class="input-small" name="piriod-end" placeholder="2020-02-11" value="{{$priod_end}}">
+                  @if($period_end !== null)
+                  終了:<input type="date" class="input-small" name="piriod-end" placeholder="2020-02-11" value="{{$period_end}}">
                   @else
                   終了:<input type="date" class="input-small" name="piriod-end" placeholder="2020-02-11">
                   @endif

--- a/resources/views/parts/detaile-search.blade.php
+++ b/resources/views/parts/detaile-search.blade.php
@@ -53,7 +53,11 @@
               <span class="search-conditions_title">期間</span>
             </div>
             <div class="search-conditions_radio">
+              @if(Session::has('period'))
+              <input type="radio" name="period" value="">なし
+              @else
               <input type="radio" name="period" value="" checked="checked">なし
+              @endif
             </div>
             <div class="search-conditions_radio">
               @if(Session::has('period') && Session::get('period') == "day")

--- a/resources/views/parts/detaile-search.blade.php
+++ b/resources/views/parts/detaile-search.blade.php
@@ -74,7 +74,7 @@
               @endif
             </div>
             <div class="search-conditions_radio">
-              @if(Settion::has('period') && Settion::get('period') == "period")
+              @if(Session::has('period') && Session::get('period') == "period")
               <input type="radio" name="period" value="period" checked="checked">期間指定
               @else
               <input type="radio" name="period" value="period">期間指定

--- a/resources/views/parts/detaile-search.blade.php
+++ b/resources/views/parts/detaile-search.blade.php
@@ -108,7 +108,7 @@
             <div class="search-conditions_radio">
               <span>
                 <label for="">
-                  @if($lgtm_min !== null)
+                  @if(Session::has('lgtm-min') && Session::get('lgtm-min') !== null)
                   最低:<input type="number" class="input-small" name="lgtm-min" placeholder="100" value="{{$lgtm_min}}">
                   @else
                   最低:<input type="number" class="input-small" name="lgtm-min" placeholder="100">
@@ -117,7 +117,7 @@
               </span>
               <span>
                 <label for="">
-                  @if($lgtm_max !== null)
+                  @if(Session::has('lgtm-max') && Session::get('lgtm-max') !== null)
                   最高:<input type="number" class="input-small" name="lgtm-max" placeholder="1000" value="{{$lgtm_max}}">
                   @else
                   最高:<input type="number" class="input-small" name="lgtm-max" placeholder="1000">

--- a/resources/views/parts/detaile-search.blade.php
+++ b/resources/views/parts/detaile-search.blade.php
@@ -53,6 +53,9 @@
               <span class="search-conditions_title">期間</span>
             </div>
             <div class="search-conditions_radio">
+              <input type="radio" name="period" value="" checked="checked">なし
+            </div>
+            <div class="search-conditions_radio">
               @if(Session::has('period') && Session::get('period') == "day")
               <input type="radio" name="period" value="day" checked="checked">1日
               @else

--- a/resources/views/parts/detaile-search.blade.php
+++ b/resources/views/parts/detaile-search.blade.php
@@ -53,28 +53,28 @@
               <span class="search-conditions_title">期間</span>
             </div>
             <div class="search-conditions_radio">
-              @if($priod == "day")
+              @if(Session::has('priod') && Session::get('priod') == "day")
               <input type="radio" name="priod" value="day" checked="checked">1日
               @else
               <input type="radio" name="priod" value="day">1日
               @endif
             </div>
             <div class="search-conditions_radio">
-              @if($priod == "week")
+              @if(Session::has('priod') && Session::get('priod') == "week")
               <input type="radio" name="priod" value="week" checked="checked">1週間
               @else
               <input type="radio" name="priod" value="week">1週間
               @endif
             </div>
             <div class="search-conditions_radio">
-              @if($priod == "month")
+              @if(Session::has('priod') && Session::get('priod') == "month")
               <input type="radio" name="priod" value="month" checked="checked">1月間
               @else
               <input type="radio" name="priod" value="month">1月間
               @endif
             </div>
             <div class="search-conditions_radio">
-              @if($priod == "period")
+              @if(Settion::has('priod') && Settion::get('priod') == "period")
               <input type="radio" name="priod" value="period" checked="checked">期間指定
               @else
               <input type="radio" name="priod" value="period">期間指定


### PR DESCRIPTION
# 何か
これまでは、詳細検索のformに検索実行前の情報を表示させるために、変数をviewにreturnして利用していた。
しかし、これだと多数の変数をreturnする必要があり、可読性にかける。
そのため、検索formの値をsessionに保存することで、returnさせる変数を減らした。

```php
    $request->session()->put('order', $request->input('order'));
    $request->session()->put('lgtm-min', $request->input('lgtm-min'));
    $request->session()->put('lgtm-max', $request->input('lgtm-max'));
    $request->session()->put('period', $request->input('period'));
    if ($request->input('period') == "period") {
      $request->session()->put('period-start', $request->input('period-start'));
      $request->session()->put('period-end', $request->input('period-end'));
    } else {
      $request->session()->forget(['period-start', 'period-end']);
    }
```

結果、本当に必要な変数のみをreturnで返すことに成功している。

```
return view('posts.index', compact('posts', 'all_posts_count', 'keyword'));
```

## 変更ファイル
### 検索処理を実行するコンとローラー
- posts.index
- posts.my_posts
- likes.index
- DetailedSearch.php

### view
- detaile-search.blade.php