### PR TITLE
withcountを利用した場合のエラーを解消

### DIFF
--- a/app/Services/DetailedSearch.php
+++ b/app/Services/DetailedSearch.php
@@ -94,7 +94,7 @@ class DetailedSearch
     if ($order == 'new') {
       $posts = $query->orderBy('posts.created_at', 'desc')->paginate(20);
     } else {
-      $posts = $query->orderBy('likes_count', 'desc')->paginate(20);
+      $posts = $query->orderBy('likes_count', 'desc')->get();
     }
     return $posts;
   }

--- a/resources/views/likes/index.blade.php
+++ b/resources/views/likes/index.blade.php
@@ -34,7 +34,9 @@
     <p>「{{ $keyword }}」に一致する記事は見つかりませんでした。</p>
     @endif
     <div class="paginate_wrapper">
+      @if(Session::has('order') && Session::get('order') == "new")
       {{ $posts->links() }}
+      @endif
     </div>
   </div>
 </div>

--- a/resources/views/posts/index.blade.php
+++ b/resources/views/posts/index.blade.php
@@ -66,7 +66,9 @@
     <p>「{{ $keyword }}」に一致する記事は見つかりませんでした。</p>
     @endif
     <div class="paginate_wrapper">
+      @if(Session::has('order') && Session::get('order') == "new")
       {{ $posts->links() }}
+      @endif
     </div>
   </div>
 </div>

--- a/resources/views/posts/my_posts.blade.php
+++ b/resources/views/posts/my_posts.blade.php
@@ -66,7 +66,9 @@
     <p>「{{ $keyword }}」に一致する記事は見つかりませんでした。</p>
     @endif
     <div class="paginate_wrapper">
+      @if(Session::has('order') && Session::get('order') == "new")
       {{ $posts->links() }}
+      @endif
     </div>
   </div>
 </div>


### PR DESCRIPTION
# 何か
withCount('like')でいいね数を集計して、SQLで絞り込み検索をしているが、withcountは->paginate()を利用した際にエラーが発生する。そのため問題なく処理できるget()に置換した

```
$posts = $query->orderBy('likes_count', 'desc')->get();
```

この関係上、`{{ $posts->links() }}`の表示をif分岐で切り分けている。

```
     @if(Session::has('order') && Session::get('order') == "new")
      {{ $posts->links() }}
      @endif
```