### PR TITLE
日付指定検索のエラー改善

### DIFF
--- a/app/Services/DetailedSearch.php
+++ b/app/Services/DetailedSearch.php
@@ -52,10 +52,8 @@ class DetailedSearch
             ['posts.created_at', '<=', date("Y-m-d 23:59:59")]
           ]);
         case "week":
-          $query->where([
-            ['posts.created_at', '>=', date("Y-m-d 00:00:00", strtotime("-1 week"))],
-            ['posts.created_at', '<=', date("Y-m-d 23:59:59")]
-          ]);
+          $query->where('posts.created_at', '>=', date("Y-m-d 00:00:00", strtotime("-1 week")));
+          $query->where('posts.created_at', '<=', date("Y-m-d H:i:s"));
         case "month":
           $query->where('posts.created_at', '>=', date("Y-m-d 00:00:00", strtotime("-1 month")));
           $query->where('posts.created_at', '<=', date("Y-m-d H:i:s"));

--- a/app/Services/DetailedSearch.php
+++ b/app/Services/DetailedSearch.php
@@ -56,16 +56,19 @@ class DetailedSearch
             ['posts.created_at', '>=', date("Y-m-d 00:00:00", strtotime("-1 week"))],
             ['posts.created_at', '<=', date("Y-m-d 23:59:59")]
           ]);
+          dd(date("Y-m-d 00:00:00", strtotime("-1 week")));
         case "month":
           $query->where([
             ['posts.created_at', '>=', date("Y-m-d 00:00:00", strtotime("-1 month"))],
             ['posts.created_at', '<=', date("Y-m-d 23:59:59")]
           ]);
         case "period":
-          $query->where([
-            ['posts.created_at', '>=', date("{$period_start} 00:00:00")],
-            ['posts.created_at', '<=', date("{$period_end} 23:59:59")]
-          ]);
+          if ($period_start !== null) {
+            $query->where('posts.created_at', '>=', date("{$period_start} 00:00:00"));
+          }
+          if ($period_end !== null) {
+            $query->where('posts.created_at', '<=', date("{$period_end} 23:59:59"));
+          }
       }
     }
 
@@ -94,7 +97,6 @@ class DetailedSearch
     // search order
     if ($order == 'new') {
       $query->orderBy('posts.created_at', 'desc');
-
     } else {
       $query->orderBy('likes_count', 'desc');
     }

--- a/app/Services/DetailedSearch.php
+++ b/app/Services/DetailedSearch.php
@@ -56,12 +56,9 @@ class DetailedSearch
             ['posts.created_at', '>=', date("Y-m-d 00:00:00", strtotime("-1 week"))],
             ['posts.created_at', '<=', date("Y-m-d 23:59:59")]
           ]);
-          dd(date("Y-m-d 00:00:00", strtotime("-1 week")));
         case "month":
-          $query->where([
-            ['posts.created_at', '>=', date("Y-m-d 00:00:00", strtotime("-1 month"))],
-            ['posts.created_at', '<=', date("Y-m-d 23:59:59")]
-          ]);
+          $query->where('posts.created_at', '>=', date("Y-m-d 00:00:00", strtotime("-1 month")));
+          $query->where('posts.created_at', '<=', date("Y-m-d H:i:s"));
         case "period":
           if ($period_start !== null) {
             $query->where('posts.created_at', '>=', date("{$period_start} 00:00:00"));

--- a/app/Services/DetailedSearch.php
+++ b/app/Services/DetailedSearch.php
@@ -47,10 +47,8 @@ class DetailedSearch
     if ($period !== null) {
       switch ($period) {
         case "day":
-          $query->where([
-            ['posts.created_at', '>=', date("Y-m-d 00:00:00")],
-            ['posts.created_at', '<=', date("Y-m-d 23:59:59")]
-          ]);
+          $query->where('posts.created_at', '>=', date("Y-m-d 00:00:00"));
+          $query->where('posts.created_at', '<=', date("Y-m-d H:i:s"));
         case "week":
           $query->where('posts.created_at', '>=', date("Y-m-d 00:00:00", strtotime("-1 week")));
           $query->where('posts.created_at', '<=', date("Y-m-d H:i:s"));


### PR DESCRIPTION
# 何か
本番環境での実行ができなくなっていた日付指定検索の改善

## どうやって

日時が23:59:59と未来の時刻を指定していたため、エラーが発生。そのため、今の時刻を取得して実行させることで改善した